### PR TITLE
fix undefined reference to `rust_oom`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 **/release
 .vscode
+*.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,12 @@ name = "ruspiro-allocator"
 version = "0.1.1"
 dependencies = [
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "ruspiro-allocator-oom 0.0.1",
+ "ruspiro-allocator-oom 0.1.0",
 ]
 
 [[package]]
 name = "ruspiro-allocator-oom"
-version = "0.0.1"
+version = "0.1.0"
 
 [metadata]
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,10 +7,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ruspiro-allocator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruspiro-allocator-oom 0.0.1",
 ]
+
+[[package]]
+name = "ruspiro-allocator-oom"
+version = "0.0.1"
 
 [metadata]
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ruspiro-allocator"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.1.0" # remember to update html_root_url
+version = "0.1.1" # remember to update html_root_url
 description = "This crate provides a simple and lightweight heap memory allocator for Raspberry Pi baremetal environments"
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-allocator/tree/v0.1.0"
-documentation = "https://docs.rs/ruspiro-allocator/0.1.0"
+repository = "https://github.com/RusPiRo/ruspiro-allocator/tree/v0.1.1"
+documentation = "https://docs.rs/ruspiro-allocator/0.1.1"
 readme = "README.md"
 keywords = ["RusPiRo", "baremetal", "allocator", "raspberrypi"]
 categories = ["no-std", "embedded"]
@@ -17,6 +17,7 @@ cc = "1.0.37"
 [lib]
 
 [dependencies]
+ruspiro-allocator-oom = { path = "./oom" }
 
 [features]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cc = "1.0.37"
 [lib]
 
 [dependencies]
-ruspiro-allocator-oom = { path = "./oom" }
+ruspiro-allocator-oom = { path = "./oom", version = "0.0.1" }
 
 [features]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cc = "1.0.37"
 [lib]
 
 [dependencies]
-ruspiro-allocator-oom = { path = "./oom", version = "0.0.1" }
+ruspiro-allocator-oom = { path = "./oom", version = "0.1.0" }
 
 [features]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["RusPiRo", "baremetal", "allocator", "raspberrypi"]
 categories = ["no-std", "embedded"]
 edition = "2018"
 
+[workspace]
+members = ["oom"]
+
 [build-dependencies]
 cc = "1.0.37"
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This crate requires to be buil with ``nightly`` as it uses the feature ``alloc_e
 To use the crate just add the following dependency to your ``Cargo.toml`` file:
 ```
 [dependencies]
-ruspiro-allocator = "0.1.0"
+ruspiro-allocator = "0.1.1"
 ```
 
 Once done the access to the custom allocator is available and will be linked with your project if you add

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,4 +1,0 @@
-# define specific additional dependencies in addition to the rust core crate when running xargo to create documentation
-# the release build done with cargo xbuild does not need this to properly compile and link all used additional crates
-[target.armv8-ruspiro.dependencies]
-alloc = {}

--- a/makefile
+++ b/makefile
@@ -35,10 +35,10 @@ test:
 	xargo test --doc --target $(TARGET)
 
 publish-dry-run:
-	xargo publish --dry-run --target $(TARGET) --all
+	xargo publish --dry-run --target $(TARGET)
 
 publish:
-	xargo publish --target $(TARGET) --all
+	xargo publish --target $(TARGET)
 
 clean:
 	cargo clean

--- a/makefile
+++ b/makefile
@@ -35,10 +35,10 @@ test:
 	xargo test --doc --target $(TARGET)
 
 publish-dry-run:
-	xargo publish --dry-run --target $(TARGET)
+	xargo publish --dry-run --target $(TARGET) --all
 
 publish:
-	xargo publish --target $(TARGET)
+	xargo publish --target $(TARGET) --all
 
 clean:
 	cargo clean

--- a/oom/Cargo.toml
+++ b/oom/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ruspiro-allocator-oom"
+authors = ["André Borrmann <pspwizard@gmx.de>"]
+version = "0.0.1" # remember to update html_root_url
+description = "The Out-Of-Memory handler implementation for the custom allocator"
+license = "Apache-2.0"
+edition = "2018"
+
+[lib]
+
+[dependencies]
+
+[features]

--- a/oom/Cargo.toml
+++ b/oom/Cargo.toml
@@ -6,6 +6,9 @@ description = "This is a `private` sub-crate of ruspiro-allocator that should on
 license = "Apache-2.0"
 repository = "https://github.com/RusPiRo/ruspiro-allocator/tree/v0.1.1"
 documentation = "https://docs.rs/ruspiro-allocator/0.1.1"
+readme = "README.md"
+keywords = ["RusPiRo", "baremetal", "allocator", "raspberrypi"]
+categories = ["no-std", "embedded"]
 edition = "2018"
 
 [lib]

--- a/oom/Cargo.toml
+++ b/oom/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruspiro-allocator-oom"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.0.1" # remember to update html_root_url
-description = "The Out-Of-Memory handler implementation for the custom allocator"
+version = "0.1.0" # remember to update html_root_url
+description = "This is a `private` sub-crate of ruspiro-allocator that should only be used as child/dependency of id. It provides the Out-Of-Memory handler implementation for the custom allocator"
 license = "Apache-2.0"
+repository = "https://github.com/RusPiRo/ruspiro-allocator/tree/v0.1.1"
+documentation = "https://docs.rs/ruspiro-allocator/0.1.1"
 edition = "2018"
 
 [lib]

--- a/oom/README.md
+++ b/oom/README.md
@@ -1,0 +1,12 @@
+# Custom Allocator OOM RusPiRo crate
+
+The need for this crate is a bit weird and contains only the implementation of the ``rust_oom`` function that need to
+be linked together with the custom allocator ``ruspiro-allocator``. This function can't be in the same crate as this leads
+to the issue that the compiler complains that this function is already defined, however if not defining it in a separate crate
+to link with the linker will complain with 'undefined reference to rust_oom'.
+
+## Usage
+This crate is a dependency from the ``ruspiro-allocator`` crate and should never used outside of it's parent.
+
+## License
+Licensed under Apache License, Version 2.0, ([LICENSE](LICENSE) or http://www.apache.org/licenses/LICENSE-2.0)

--- a/oom/src/lib.rs
+++ b/oom/src/lib.rs
@@ -1,0 +1,22 @@
+/*********************************************************************************************************************** 
+ * Copyright (c) 2019 by the authors
+ * 
+ * Author: André Borrmann 
+ * License: Apache License 2.0
+ **********************************************************************************************************************/
+#![doc(html_root_url = "https://docs.rs/ruspiro-allocator-oom/0.0.1")]
+#![no_std]
+
+//! # Allocator OutOfMemory implementation
+//! 
+
+// putting this into the same crate that defines the alloc_error_handler lead to "rust_oom"
+// already defined during compile time, but leaving this out there lead to "undefined reference to rust_oom" 
+// .... WTF ...
+// so defining this in this crate that does not define the alloc_error_handler and link it to the allocator crate
+// -> this wotks fine....
+#[no_mangle]
+fn rust_oom() -> ! {
+    // well, currently there is nothing we could do on out-of-memory other than halt the core
+    loop { }
+}

--- a/oom/src/lib.rs
+++ b/oom/src/lib.rs
@@ -4,7 +4,7 @@
  * Author: André Borrmann 
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-allocator-oom/0.0.1")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-allocator-oom/0.1.0")]
 #![no_std]
 
 //! # Allocator OutOfMemory implementation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,13 @@
  * Author: André Borrmann 
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-allocator/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-allocator/0.1.1")]
 #![no_std]
 #![feature(alloc_error_handler)]
 //! # Custom Allocator for HEAP memory allocations
 //! 
 //! This crate provides a custom allocator for heap memory. If any baremetal crate uses functions and structures from
-//! the ``core::alloc`` crate an allocator need to be provided as well. However, this crate does not export any public
+//! the ``alloc`` crate an allocator need to be provided as well. However, this crate does not export any public
 //! API to be used. It only encapsulates the memeory allocator that shall be linked into the binary.
 //! 
 //! # Usage
@@ -35,6 +35,9 @@
 //! }
 //! ```
 //! 
+
+// `rust_oom` function need to be provided in an extra lib crate for some weird resons...
+extern crate ruspiro_allocator_oom;
 
 /// this specifies the custom memory allocator to use whenever heap memory need to be allocated or freed
 #[global_allocator]
@@ -69,6 +72,17 @@ fn alloc_error_handler(_: Layout) -> ! {
     // TODO: how to handle memory allocation errors?
     loop { }
 }
+
+// putting this here leasd to "rust_oom" already defined during compile time
+// leaving this out lead to "undefined reference to rust_oom" .... WTF ...
+// need to put this into another crate that does not define the alloc_error_handler 
+// and only provides this symbol during compile time
+// 
+/*#[no_mangle]
+fn rust_oom() -> ! {
+    loop { }
+}
+*/
 
 extern "C" {
     // external functions pre-compiled with the build script from c or assembly files


### PR DESCRIPTION
the function "rust_oom" was missing, which lead to an undefined reference error unless the user of this crate provided his own function. But this should not be the case! The function now comes with this crate as well.