### PR TITLE
fix cargo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,4 +2,4 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ruspiro-allocator"
-version = "0.5.0"
+version = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-allocator"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.5.0" # remember to update html_root_url
+version = "0.4.2" # remember to update html_root_url
 description = """
 Simple and lightweight heap memory allocator for Raspberry Pi baremetal environments.
 """


### PR DESCRIPTION
Crate was published with version 0.5.0 when it should be 0.4.2