### PR TITLE
Fix error with docu generation on doc.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## :peach: v0.4.4
+
+- ### :wrench: Maintenance
+
+  - fix issue generating the documentation at doc.rs which failes with a custom build target. So fall-back at docu generation to the standard target `aarch64-unknown-linux-gnu` and do not include the `.cargo/config.toml` when pushing to crates.io as this is not needed if the crate is used as a dependency and seem to lead to the doc generation issue even though a specific target was choosen in the `Cargo.toml` file for the doc.
+
 ## :peach: v0.4.3
 
 This version migtrates to GitHub Actions as new CI/CD pipeline. In addition it introduces a custom build target used to build the crate for the Raspberry Pi Aarch64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ruspiro-allocator"
-version = "0.4.3"
+version = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-allocator"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.3" # remember to update html_root_url
+version = "0.4.4" # remember to update html_root_url
 description = """
 Simple and lightweight heap memory allocator for Raspberry Pi baremetal environments.
 """
@@ -13,7 +13,7 @@ keywords = ["RusPiRo", "baremetal", "allocator", "raspberrypi"]
 categories = ["no-std", "embedded"]
 edition = "2018"
 links = "ruspiro_allocator"
-exclude = ["Makefile.toml"]
+exclude = ["Makefile.toml", ".cargo/config.toml"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -28,8 +28,9 @@ is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-allocator" }
 [dependencies]
 
 [features]
-ruspiro_pi3 = [ ]
+
+[package.metadata.docs.rs]
+targets = ["aarch64-unknown-linux-gnu"]
+features = []
 
 [patch.crates-io]
-
-

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,23 +21,18 @@ command = "cargo"
 args = ["build", "--release", "--features", "${FEATURES}"]
 
 [tasks.pi3]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "" }
 run_task = "build"
 
 [tasks.clippy]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "" }
 command = "cargo"
 args = ["clippy", "--features", "${FEATURES}"]
 
 [tasks.doc]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "" }
 command = "cargo"
-args = ["doc", "--open", "--features", "${FEATURES}"]
-
-[tasks.doctest]
-env = { FEATURES = "ruspiro_pi3" }
-command = "cargo"
-args = ["test", "--doc", "--features", "${FEATURES}"]
+args = ["doc", "--target", "aarch64-unknown-linux-gnu", "--open", "--features", "${FEATURES}"]
 
 [tasks.clean]
 command = "cargo"


### PR DESCRIPTION
Fix the issue with docu generation on doc.rs for custom build target. Remove the `.coarg/config.toml` file from publishing to crates.io to build docu with a standard target.