### PR TITLE
Fix memory ordering for atomic operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## :strawberry: v0.4.5
+
+- ### :detective: Bug-Fixes
+
+  - Fix an issue with the memory ordering used for some atomic operations.
+
+- ### :wrench: Maintenance
+
+  - Add the `rlibc` crate as an dependency and the `extern crate rlibc` to this library crate. This brings the built-in core memory functions like *memset*, *memcpy* into scope for linking in the final binary that uses this crate. This is quite convenient as those functions are required anyway as soon one deals with heap memory allocations and thus reduces the dependency list from the final binary and ensures this is not forgotten.
+
 ## :peach: v0.4.4
 
 - ### :wrench: Maintenance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "rlibc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
+
+[[package]]
 name = "ruspiro-allocator"
-version = "0.4.4"
+version = "0.4.5"
+dependencies = [
+ "rlibc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-allocator"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.4" # remember to update html_root_url
+version = "0.4.5" # remember to update html_root_url
 description = """
 Simple and lightweight heap memory allocator for Raspberry Pi baremetal environments.
 """
@@ -26,6 +26,7 @@ is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-allocator" }
 # cc = "1.0"
 
 [dependencies]
+rlibc = "~1.0.0"
 
 [features]
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ API to be used. It only encapsulates the memory allocator that shall be linked i
 ## Pre-Requisits
 
 This crate requires to be buil with ``nightly`` as it uses the feature ``alloc_error_handler`` which is not stable yet.
+When this crate is used with the Raspberry Pi it also requires the **MMU** to be configured and enables as it uses atomic operations to provide the lock free memory allocations.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@
 //! the ``alloc`` crate an allocator need to be provided as well. However, this crate does not export any public
 //! API to be used. It only encapsulates the memeory allocator that shall be linked into the binary.
 //!
+//! # Prerequisit
+//!
+//! The lock free memory allocations use atomic operations. Thus to properly work on a Raspberry Pi the MMU is required
+//! to be configured and enabled. Otherwise memory allocations will just hang the cores.
+//!
 //! # Usage
 //!
 //! To link the custom allocator with your project just add the usage to your main crate rust file like so:
@@ -34,6 +39,10 @@
 //! }
 //! ```
 //!
+
+// this is crate is required to bring the core memory functions like memset, memcpy etc. into the link process
+#[doc(hidden)]
+extern crate rlibc;
 
 /// this specifies the custom memory allocator to use whenever heap memory need to be allocated or freed
 #[cfg_attr(not(any(test, doctest)), global_allocator)]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -186,8 +186,8 @@ pub(crate) fn alloc(req_size: usize, alignment: usize) -> *mut u8 {
   let _ = HEAP_START.compare_exchange(
     0,
     unsafe { &__heap_start as *const usize as usize },
-    Ordering::AcqRel,
-    Ordering::Release,
+    Ordering::SeqCst,
+    Ordering::Relaxed,
   );
 
   // calculate the required size to be allocated including descriptor size and alignment
@@ -250,8 +250,8 @@ pub(crate) fn alloc_page(num: usize, page_size: usize) -> *mut u8 {
   let _ = HEAP_START.compare_exchange(
     0,
     unsafe { &__heap_start as *const usize as usize },
-    Ordering::AcqRel,
-    Ordering::Release,
+    Ordering::SeqCst,
+    Ordering::Relaxed,
   );
 
   // from the current HEAP_START calculate the next start address of a page
@@ -316,8 +316,8 @@ pub(crate) fn free(address: *mut u8) {
     .compare_exchange(
       heap_check,
       descriptor_addr,
-      Ordering::AcqRel,
-      Ordering::AcqRel,
+      Ordering::SeqCst,
+      Ordering::Relaxed,
     )
     .is_ok()
   {


### PR DESCRIPTION
- Fix an issue with the used memory ordering for some atomic operations.
- introduce the *rlibc* crate as dependency to ensure core memory functions like `memset`, `memcpy`... will be also linked into the final binary when using this allocator crate. So the user of the crate can't forget this additional required dependency for proper linkage of the final binary.